### PR TITLE
fix: disable legacy setssdroot.service to prevent boot hang

### DIFF
--- a/configure_ssd_boot.sh
+++ b/configure_ssd_boot.sh
@@ -135,12 +135,24 @@ sed "/\\/boot\\/efi / s|UUID=[^ ]*|UUID=${EFI_UUID}|" "$FSTAB" > "${FSTAB}.tmp" 
 }
 
 echo "Updated $FSTAB with EFI UUID=${EFI_UUID}"
+ 
+# Disable legacy root-pivot services that conflict with direct NVMe boot.
+# These may have been cloned from the source media if the user previously
+# used the rootOnNVMe workflow or similar root-pivot method. If left enabled,
+# setssdroot.service will attempt to pivot root to a device that is already
+# the root filesystem, causing an RCU preempt stall and a hung boot.
+LEGACY_SERVICE="$MOUNT_POINT/etc/systemd/system/setssdroot.service"
+if [ -f "$LEGACY_SERVICE" ]; then
+  chroot "$MOUNT_POINT" /bin/bash -c "systemctl disable setssdroot.service" 2>/dev/null
+  echo "Disabled legacy setssdroot.service (not needed for direct NVMe boot)"
+fi
+ 
 sync
 # Unmount the root partition and clean up
 if mountpoint -q "$MOUNT_POINT"; then
   umount "$MOUNT_POINT"
 fi
 rmdir "$MOUNT_POINT"
-
+ 
 echo "System configurations updated on the SSD."
 echo "You may need to change the boot order to prioritize the SSD."


### PR DESCRIPTION
Fixes #12 

### Summary

`configure_ssd_boot.sh` correctly updates `extlinux.conf` and `fstab` for direct NVMe boot, but does not check for or disable conflicting legacy root-pivot services that may have been cloned from the source media by `copy_partitions.sh`.

If the source SD card had `setssdroot.service` enabled (from the older [rootOnNVMe](https://github.com/jetsonhacks/rootOnNVMe) workflow), it gets cloned to the NVMe and causes an RCU preempt stall on boot, the service tries to pivot root to a device that is already the root filesystem.

### Fix

Added a cleanup step after the `fstab` update (line 137) that checks for and disables the legacy `setssdroot.service` on the target NVMe before unmounting.

### Diff

```diff
--- a/configure_ssd_boot.sh
+++ b/configure_ssd_boot.sh
@@ -135,6 +135,18 @@
 }
 
 echo "Updated $FSTAB with EFI UUID=${EFI_UUID}"
+
+# Disable legacy root-pivot services that conflict with direct NVMe boot.
+# These may have been cloned from the source media if the user previously
+# used the rootOnNVMe workflow or similar root-pivot method. If left enabled,
+# setssdroot.service will attempt to pivot root to a device that is already
+# the root filesystem, causing an RCU preempt stall and a hung boot.
+LEGACY_SERVICE="$MOUNT_POINT/etc/systemd/system/setssdroot.service"
+if [ -f "$LEGACY_SERVICE" ]; then
+  chroot "$MOUNT_POINT" /bin/bash -c "systemctl disable setssdroot.service" 2>/dev/null
+  echo "Disabled legacy setssdroot.service (not needed for direct NVMe boot)"
+fi
+
 sync
 # Unmount the root partition and clean up
 if mountpoint -q "$MOUNT_POINT"; then
```